### PR TITLE
DATASHARE-141 Add Government Usage Banner

### DIFF
--- a/public/js/session.js
+++ b/public/js/session.js
@@ -1,0 +1,34 @@
+const sessionStorageTransfer = (event) => {
+  let $event = event;
+  if (!$event) {
+    $event = window.event;
+  } // ie suq
+  if (!$event.newValue) return; // do nothing if no value to work with
+  if ($event.key === 'getSessionStorage') {
+    // another tab asked for the sessionStorage -> send it
+    localStorage.setItem('sessionStorage', JSON.stringify(sessionStorage));
+    // the other tab should now have it, so we're done with it.
+    localStorage.removeItem('sessionStorage'); // <- could do short timeout as well.
+  } else if ($event.key === 'sessionStorage' && !sessionStorage.length) {
+    // another tab sent data <- get it
+    const data = JSON.parse($event.newValue);
+    Object.keys(data).forEach((key) => {
+      sessionStorage.setItem(key, data[key]);
+    });
+  } else if ($event.key === 'logout') {
+    sessionStorage.clear();
+  }
+};
+
+// listen for changes to localStorage
+if (window.addEventListener) {
+  window.addEventListener('storage', sessionStorageTransfer, false);
+} else {
+  window.addEventListener('onstorage', sessionStorageTransfer);
+}
+
+// Ask other tabs for session storage (this is ONLY to trigger 'storage' event)
+if (!sessionStorage.length) {
+  localStorage.setItem('getSessionStorage', 'true');
+  localStorage.removeItem('getSessionStorage');
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -139,6 +139,7 @@ export default function RootLayout({
     <html lang="en">
       <head>
         <Script {...adobeDTM} />
+        <script src="/js/session.js" async></script>
       </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} ${openSans.variable} ${poppins.variable} ${lato.variable} ${inter.variable} ${nunitoSans.variable} ${nunito.variable} ${publicSans.variable} ${rubik.variable} ${roboto.variable} antialiased bg-white min-h-screen`}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,9 @@
 import type { Metadata } from "next";
 import "./globals.css";
-import { Geist, Geist_Mono, Open_Sans, Poppins, Lato, Inter, Nunito_Sans, Nunito, Public_Sans, Rubik } from "next/font/google";
+import { Geist, Geist_Mono, Open_Sans, Poppins, Lato, Inter, Nunito_Sans, Nunito, Public_Sans, Rubik, Roboto } from "next/font/google";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
+import OverlayWindow from "@/components/OverlayWindow";
 import Script from "next/script";
 
 /**
@@ -66,6 +67,12 @@ const publicSans = Public_Sans({
 const rubik = Rubik({
   variable: "--font-rubik",
   subsets: ["latin"],
+});
+
+const roboto = Roboto({
+  variable: "--font-roboto",
+  subsets: ['latin'],
+  weight: ['300', '400', '500', '700'],
 });
 
 export const metadata: Metadata = {
@@ -134,9 +141,10 @@ export default function RootLayout({
         <Script {...adobeDTM} />
       </head>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} ${openSans.variable} ${poppins.variable} ${lato.variable} ${inter.variable} ${nunitoSans.variable} ${nunito.variable} ${publicSans.variable} ${rubik.variable} antialiased bg-white min-h-screen`}
+        className={`${geistSans.variable} ${geistMono.variable} ${openSans.variable} ${poppins.variable} ${lato.variable} ${inter.variable} ${nunitoSans.variable} ${nunito.variable} ${publicSans.variable} ${rubik.variable} ${roboto.variable} antialiased bg-white min-h-screen`}
       >
         <Header />
+        <OverlayWindow />
         {children}
         <Footer />
       </body>

--- a/src/components/OverlayWindow/index.test.tsx
+++ b/src/components/OverlayWindow/index.test.tsx
@@ -1,0 +1,241 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import OverlayWindow from './index';
+import { afterEach, beforeEach, describe, expect, it, vi, Mock } from 'vitest';
+
+describe('OverlayWindow', () => {
+  let sessionStorageMock: Storage;
+
+  beforeEach(() => {
+    // Mock sessionStorage
+    sessionStorageMock = {
+      getItem: vi.fn(),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+      clear: vi.fn(),
+      key: vi.fn(),
+      length: 0,
+    };
+
+    Object.defineProperty(window, 'sessionStorage', {
+      value: sessionStorageMock,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('Component Rendering', () => {
+    it('renders the dialog when sessionStorage overlayLoad is not set', () => {
+      (sessionStorageMock.getItem as Mock).mockReturnValue(null);
+
+      render(<OverlayWindow />);
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      expect(screen.getByText('Warning')).toBeInTheDocument();
+    });
+
+    it('does not render the dialog when sessionStorage overlayLoad is true', () => {
+      (sessionStorageMock.getItem as Mock).mockReturnValue('true');
+
+      render(<OverlayWindow />);
+
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('renders with correct ARIA attributes', () => {
+      (sessionStorageMock.getItem as Mock).mockReturnValue(null);
+
+      render(<OverlayWindow />);
+
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toHaveAttribute('aria-modal', 'true');
+      expect(dialog).toHaveAttribute('aria-labelledby', 'government-usage-dialog-title');
+    });
+  });
+
+  describe('Dialog Visibility', () => {
+    it('shows the dialog initially when not dismissed', async () => {
+      (sessionStorageMock.getItem as Mock).mockReturnValue(null);
+
+      render(<OverlayWindow />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+    });
+
+    it('hides the dialog when dismissed', async () => {
+      (sessionStorageMock.getItem as Mock).mockReturnValue('true');
+
+      render(<OverlayWindow />);
+
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Continue Button Functionality', () => {
+    it('renders the Continue button', () => {
+      (sessionStorageMock.getItem as Mock).mockReturnValue(null);
+
+      render(<OverlayWindow />);
+
+      const button = screen.getByRole('button', { name: /continue/i });
+      expect(button).toBeInTheDocument();
+    });
+
+    it('closes the dialog when Continue button is clicked', () => {
+      (sessionStorageMock.getItem as Mock).mockReturnValue(null);
+
+      render(<OverlayWindow />);
+
+      const button = screen.getByRole('button', { name: /continue/i });
+      fireEvent.click(button);
+
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('sets sessionStorage overlayLoad to true when Continue button is clicked', () => {
+      (sessionStorageMock.getItem as Mock).mockReturnValue(null);
+
+      render(<OverlayWindow />);
+
+      const button = screen.getByRole('button', { name: /continue/i });
+      fireEvent.click(button);
+
+      expect(sessionStorageMock.setItem).toHaveBeenCalledWith('overlayLoad', 'true');
+    });
+
+    it('does not crash if sessionStorage is undefined when closing', () => {
+      (sessionStorageMock.getItem as Mock).mockReturnValue(null);
+      Object.defineProperty(window, 'sessionStorage', {
+        value: undefined,
+        writable: true,
+      });
+
+      render(<OverlayWindow />);
+
+      const button = screen.getByRole('button', { name: /continue/i });
+      
+      expect(() => {
+        fireEvent.click(button);
+      }).not.toThrow();
+    });
+  });
+
+  describe('SessionStorage Integration', () => {
+    it('checks sessionStorage on mount', () => {
+      (sessionStorageMock.getItem as Mock).mockReturnValue(null);
+
+      render(<OverlayWindow />);
+
+      expect(sessionStorageMock.getItem).toHaveBeenCalledWith('overlayLoad');
+    });
+
+    it('respects existing sessionStorage value', () => {
+      (sessionStorageMock.getItem as Mock).mockReturnValue('true');
+
+      render(<OverlayWindow />);
+
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('handles missing sessionStorage gracefully', () => {
+      Object.defineProperty(window, 'sessionStorage', {
+        value: undefined,
+        writable: true,
+      });
+
+      expect(() => {
+        render(<OverlayWindow />);
+      }).not.toThrow();
+    });
+  });
+
+  describe('Dialog Structure', () => {
+    it('renders the dialog title', () => {
+      (sessionStorageMock.getItem as Mock).mockReturnValue(null);
+
+      render(<OverlayWindow />);
+
+      const title = screen.getByText('Warning');
+      expect(title).toBeInTheDocument();
+      expect(title).toHaveAttribute('id', 'government-usage-dialog-title');
+    });
+
+    it('renders the backdrop', () => {
+      (sessionStorageMock.getItem as Mock).mockReturnValue(null);
+
+      render(<OverlayWindow />);
+
+      const dialog = screen.getByRole('dialog');
+      const backdrop = dialog.querySelector('.bg-\\[\\#00000047\\]');
+      expect(backdrop).toBeInTheDocument();
+    });
+
+    it('backdrop has pointer-events-none class', () => {
+      (sessionStorageMock.getItem as Mock).mockReturnValue(null);
+
+      render(<OverlayWindow />);
+
+      const dialog = screen.getByRole('dialog');
+      const backdrop = dialog.querySelector('.pointer-events-none');
+      expect(backdrop).toBeInTheDocument();
+    });
+  });
+
+  describe('Unmounting', () => {
+    it('can be safely unmounted', () => {
+      (sessionStorageMock.getItem as Mock).mockReturnValue(null);
+
+      const { unmount } = render(<OverlayWindow />);
+
+      expect(() => {
+        unmount();
+      }).not.toThrow();
+    });
+
+    it('removes the dialog from DOM when unmounted', () => {
+      (sessionStorageMock.getItem as Mock).mockReturnValue(null);
+
+      const { unmount } = render(<OverlayWindow />);
+      
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      
+      unmount();
+      
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('State Management', () => {
+    it('maintains open state correctly after closing', () => {
+      (sessionStorageMock.getItem as Mock).mockReturnValue(null);
+
+      render(<OverlayWindow />);
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+      const button = screen.getByRole('button', { name: /continue/i });
+      fireEvent.click(button);
+
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('does not reopen after being closed', () => {
+      (sessionStorageMock.getItem as Mock).mockReturnValue(null);
+
+      const { rerender } = render(<OverlayWindow />);
+
+      const button = screen.getByRole('button', { name: /continue/i });
+      fireEvent.click(button);
+
+      rerender(<OverlayWindow />);
+
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/OverlayWindow/index.tsx
+++ b/src/components/OverlayWindow/index.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import React, { JSX, useEffect, useMemo, useState } from 'react';
+import { OverlayText } from '@/config/OverlayText';
+
+/**
+ * Provides the Government Usage Warning banner and related logic.
+ * 
+ * @returns The Government Usage banner component, which is conditionally rendered based on session storage.
+ */
+const OverlayWindow: React.FC = () => {
+  const [open, setOpen] = useState<boolean>(false);
+
+  const handleClose = () => {
+    setOpen(false);
+    if (typeof window !== 'undefined' && typeof window.sessionStorage !== 'undefined') {
+      window.sessionStorage.setItem('overlayLoad', 'true');
+    }
+  };
+
+  const content = useMemo<JSX.Element[]>(() => 
+    OverlayText.content.map((item) => (
+      <p key={item.substring(0, 30)} className="text-[14px] text-black mb-[10px] last:mb-0">
+        {item}
+      </p>
+    )
+  ), []);
+
+  const list = useMemo<JSX.Element[]>(() => 
+    OverlayText.list.map((item) => (
+      <li
+        key={item.substring(0, 30)}
+        className="text-[14px] pt-[3px] pl-[26px] flex items-start mt-[7px] first:-mt-[8px]"
+        >
+        <span className="mt-[7px] mr-[11px] inline-block h-[5.5px] w-[5.5px] min-w-[5.5px] rounded-full bg-black flex-shrink-0" />
+        <span>{item}</span>
+      </li>
+    )
+  ), []);
+
+  useEffect(() => {
+    if (window?.sessionStorage?.getItem('overlayLoad') !== 'true') {
+      setOpen(true);
+    }
+  }, []);
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-[1200] flex items-center justify-center font-['Roboto']"
+      role="dialog"
+      aria-labelledby="government-usage-dialog-title"
+      aria-modal="true"
+    >
+      <div className="absolute inset-0 bg-[#00000047] pointer-events-none" />
+      <div className="relative ml-[15px]">
+        <div className="w-[770px] h-[620px] rounded-[5px] bg-white px-[20px] flex flex-col">
+          <div className="py-[15px] pr-[15px] pl-0">
+            <h2 id="government-usage-dialog-title" className="text-[22px] text-black font-medium leading-[1.6] tracking-[0.0075em]">
+              Warning
+            </h2>
+          </div>
+          <div className="h-px w-full bg-[#e0e0e0]" />
+          <div className="pt-[20px] text-[#000045] text-[14px] flex-1 overflow-auto tracking-[0.00938em]">
+            {content}
+            <p className="text-[14px] text-black mb-[10px]">
+              {'By using this system, you understand and consent to the following: '}
+            </p>
+            <ul className="mt-0 pt-0 text-[14px] pr-[6px]">
+              {list}
+            </ul>
+          </div>
+          <div className="h-px w-full bg-[#e0e0e0]" />
+          <div className="h-[75px] flex justify-end items-center pr-[10px] pt-[30px] pb-[25px]">
+            <button
+              type="button"
+              onClick={handleClose}
+              className="w-[133px] h-[35px] bg-[#337ab7] text-white normal-case hover:bg-[#2e6da4] rounded-[4px] font-medium font-['Roboto'] text-[0.875rem] leading-[1.6] tracking-[0.02857em]"
+            >
+              Continue
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default OverlayWindow;

--- a/src/config/OverlayText.ts
+++ b/src/config/OverlayText.ts
@@ -1,0 +1,12 @@
+export const OverlayText = {
+    content: [
+        "This warning banner provides privacy and security notices consistent with applicable federal laws, directives, and other federal guidance for accessing this Government system, which includes (1) this computer network, (2) all computers connected to this network, and (3) all devices and storage media attached to this network or to a computer on this network.",
+        "This system is provided for Government-authorized use only.",
+        "Unauthorized or improper use of this system is prohibited and may result in disciplinary action and/or civil and criminal penalties.",
+        "Personal use of social media and networking sites on this system is limited as to not interfere with official work duties and is subject to monitoring."
+    ],
+    list: [
+        "The Government may monitor, record, and audit your system usage, including usage of personal devices and email systems for official duties or to conduct HHS business. Therefore, you have no reasonable expectation of privacy regarding any communication or data transiting or stored on this system. At any time, and for any lawful Government purpose, the government may monitor, intercept, and search and seize any communication or data transiting or stored on this system.",
+        "Any communication or data transiting or stored on this system may be disclosed or used for any lawful Government purpose."
+    ]
+} as const;


### PR DESCRIPTION
### Overview

This PR adds the standard Government Usage banner, as well as the standard session sync functionality. 

### Change Details (Specifics)

- Migrate the INS/C3DC government usage warning banner from MUI to Tailwind
- Add unit tests for the banner functionality
- Add session sync script from Bento
- Add Roboto font for the banner styling

### Related Ticket(s)

DATASHARE-141 